### PR TITLE
doc: Fix typo on the description

### DIFF
--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -140,7 +140,7 @@
       },
       {
         "name": "headers",
-        "description": "Include headings"
+        "description": "Include headers"
       },
       {
         "name": "strict",


### PR DESCRIPTION
That field even seems deprecated, we can consider removing it in the future