### PR TITLE
Bump markdownlint to 0.41.1

### DIFF
--- a/docs/description/MD001.md
+++ b/docs/description/MD001.md
@@ -37,7 +37,7 @@ level at a time:
 ### Another Heading 3
 ```
 
-If [YAML](https://en.wikipedia.org/wiki/YAML) front matter is present and
+If [YAML](https://wikipedia.org/wiki/YAML) front matter is present and
 contains a `title` property (commonly used with blog posts), this rule treats
 that as a top level heading and will report a violation if the actual first
 heading is not a level 2 heading. To use a different property name in the

--- a/docs/description/MD011.md
+++ b/docs/description/MD011.md
@@ -20,7 +20,7 @@ To fix this, swap the `[]` and `()` around:
 [Correct link syntax](https://www.example.com/)
 ```
 
-Note: [Markdown Extra](https://en.wikipedia.org/wiki/Markdown_Extra)-style
+Note: [Markdown Extra](https://wikipedia.org/wiki/Markdown_Extra)-style
 footnotes do not trigger this rule:
 
 ```markdown

--- a/docs/description/MD022.md
+++ b/docs/description/MD022.md
@@ -6,6 +6,8 @@ Aliases: `blanks-around-headings`
 
 Parameters:
 
+- `include_front_matter`: Include front matter content (`boolean`, default
+  `false`)
 - `lines_above`: Blank lines above heading (`integer|integer[]`, default `1`)
 - `lines_below`: Blank lines below heading (`integer|integer[]`, default `1`)
 
@@ -46,6 +48,19 @@ Notes: If `lines_above` or `lines_below` are configured to require more than one
 blank line, [MD012/no-multiple-blanks](md012.md) should also be customized. This
 rule checks for *at least* as many blank lines as specified; any extra blank
 lines are ignored.
+
+By default, [YAML](https://wikipedia.org/wiki/YAML) front matter is ignored, so
+the following document reports no violations:
+
+```markdown
+---
+title: Title
+---
+## Heading
+```
+
+To require the configured number of blank lines between front matter content and
+a document's first heading, set the `include_front_matter` parameter to `true`.
 
 Rationale: Aside from aesthetic reasons, some parsers, including `kramdown`,
 will not parse headings that don't have a blank line before, and will parse them

--- a/docs/description/MD025.md
+++ b/docs/description/MD025.md
@@ -35,7 +35,7 @@ lower-level headings (h2, h3, etc.):
 Note: The `level` parameter can be used to change the top-level (ex: to h2) in
 cases where an h1 is added externally.
 
-If [YAML](https://en.wikipedia.org/wiki/YAML) front matter is present and
+If [YAML](https://wikipedia.org/wiki/YAML) front matter is present and
 contains a `title` property (commonly used with blog posts), this rule treats
 that as a top level heading and will report a violation for any subsequent
 top-level headings. To use a different property name in the front matter,

--- a/docs/description/MD026.md
+++ b/docs/description/MD026.md
@@ -37,4 +37,4 @@ Rationale: Headings are not meant to be full sentences. More information:
 [Punctuation at the end of headers][end-punctuation].
 
 [end-punctuation]: https://cirosantilli.com/markdown-style-guide#punctuation-at-the-end-of-headers
-[html-entity-references]: https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
+[html-entity-references]: https://wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references

--- a/docs/description/MD028.md
+++ b/docs/description/MD028.md
@@ -5,29 +5,33 @@ Tags: `blockquote`, `whitespace`
 Aliases: `no-blanks-blockquote`
 
 This rule is triggered when two blockquote blocks are separated by nothing
-except for a blank line:
+but a blank line:
 
 ```markdown
 > This is a blockquote
 > which is immediately followed by
 
-> this blockquote. Unfortunately
-> In some parsers, these are treated as the same blockquote.
+> this blockquote. In some cases,
+> these may be merged into one blockquote.
 ```
 
-To fix this, ensure that any blockquotes that are right next to each other
-have some text in between:
+To fix this, ensure that consecutive blockquotes have text (or an HTML comment)
+in between:
 
 ```markdown
 > This is a blockquote.
 
-And Jimmy also said:
+This is paragraph text.
 
-> This too is a blockquote.
+> This is a second blockquote.
+
+<!-- This is an HTML comment -->
+
+> This is a third blockquote.
 ```
 
-Alternatively, if they are supposed to be the same quote, then add the
-blockquote symbol at the beginning of the blank line:
+If they are meant to be a single quote, add the blockquote symbol at the
+beginning of the blank line:
 
 ```markdown
 > This is a blockquote.

--- a/docs/description/MD029.md
+++ b/docs/description/MD029.md
@@ -55,7 +55,8 @@ Example invalid list for all styles:
 3. Done.
 ```
 
-This rule supports 0-prefixing ordered list items for uniform indentation:
+This rule supports 0-prefixing list items for uniform indentation and will
+preserve that when fixing:
 
 ```markdown
 ...
@@ -63,7 +64,16 @@ This rule supports 0-prefixing ordered list items for uniform indentation:
 09. Item
 10. Item
 11. Item
+```
+
+When list items appear to be right-aligned, fixes will maintain that alignment:
+
+```markdown
 ...
+ 8. Item
+ 9. Item
+10. Item
+11. Item
 ```
 
 Note: This rule will report violations for cases like the following where an

--- a/docs/description/MD034.md
+++ b/docs/description/MD034.md
@@ -21,7 +21,7 @@ For more info, visit <https://www.example.com/> or email <user@example.com>.
 
 If a URL or email address contains non-ASCII characters, it may be not be
 handled as intended even when angle brackets are present. In such cases,
-[percent-encoding](https://en.m.wikipedia.org/wiki/Percent-encoding) can be used
+[percent-encoding](https://wikipedia.org/wiki/Percent-encoding) can be used
 to comply with the required syntax for URL and email.
 
 Note: To include a bare URL or email without it being converted into a link,

--- a/docs/description/MD035.md
+++ b/docs/description/MD035.md
@@ -8,8 +8,8 @@ Parameters:
 
 - `style`: Horizontal rule style (`string`, default `consistent`)
 
-This rule is triggered when inconsistent styles of horizontal rules are used
-in the document:
+This rule is triggered when inconsistent styles of horizontal rules (also known
+as "thematic breaks") are used in a document:
 
 ```markdown
 ---
@@ -23,15 +23,22 @@ in the document:
 ****
 ```
 
-To fix this, use the same horizontal rule everywhere:
+To fix this, use the same horizontal rule syntax everywhere:
 
 ```markdown
 ---
 
 ---
+
+---
 ```
 
-The configured style can ensure all horizontal rules use a specific string or it
-can ensure all horizontal rules match the first horizontal rule (`consistent`).
+The `style` parameter's default value `consistent` ensures all horizontal rules
+in a document match the first horizontal rule in that document. To enforce a
+specific pattern of characters, set the `style` parameter to that string (e.g.,
+`"* * *"`).
+
+Note: In order to be recognized as a horizontal rule, a line must contain three
+or more matching `-`, `_`, or `*` characters with optional space between.
 
 Rationale: Consistent formatting makes it easier to understand a document.

--- a/docs/description/MD041.md
+++ b/docs/description/MD041.md
@@ -59,6 +59,6 @@ in cases where an `h1` is added externally.
 Rationale: The top-level heading often acts as the title of a document. More
 information: <https://cirosantilli.com/markdown-style-guide#top-level-header>.
 
-[HTML]: https://en.wikipedia.org/wiki/HTML
+[HTML]: https://wikipedia.org/wiki/HTML
 [RegExp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
-[YAML]: https://en.wikipedia.org/wiki/YAML
+[YAML]: https://wikipedia.org/wiki/YAML

--- a/docs/description/MD042.md
+++ b/docs/description/MD042.md
@@ -20,6 +20,10 @@ Empty fragments will trigger this rule:
 
 ```markdown
 [an empty fragment](#)
+
+[an empty link definition][empty]
+
+[empty]: #
 ```
 
 But non-empty fragments will not:
@@ -27,6 +31,8 @@ But non-empty fragments will not:
 ```markdown
 [a valid fragment](#fragment)
 ```
+
+Empty link definitions
 
 Rationale: Empty links do not lead anywhere and therefore don't function as
 links.

--- a/docs/description/MD045.md
+++ b/docs/description/MD045.md
@@ -45,4 +45,4 @@ content of an image for people who may not be able to see it.
 [aria-hidden]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden
 [phase2technology]: https://www.phase2technology.com/blog/no-more-excuses
 [w3c]: https://www.w3.org/WAI/alt/
-[wikipedia]: https://en.wikipedia.org/wiki/Alt_attribute
+[wikipedia]: https://wikipedia.org/wiki/Alt_attribute

--- a/docs/description/MD060.md
+++ b/docs/description/MD060.md
@@ -10,6 +10,8 @@ Parameters:
 - `style`: Table column style (`string`, default `any`, values `aligned` /
   `any` / `compact` / `tight`)
 
+Fixable: Some violations can be fixed by tooling
+
 This rule is triggered when the column separator pipe characters (`|`) of a
 [GitHub Flavored Markdown table][gfm-table-060] are used inconsistently.
 
@@ -81,6 +83,16 @@ Style `tight` with `aligned_delimiter`:
 |N|No|
 ```
 
+Violations for styles `compact` and `tight` are simple/independent and can be
+fixed automatically. However, fixing even single violations for style `aligned`
+may require modifying the entire table, and therefore are not automatic:
+
+```markdown
+|Alpha |Delta|
+|------|-----|
+|Charlie|Beta|
+```
+
 **Note**: This rule does not require leading/trailing pipe characters, so this
 is also a valid table for style `compact`:
 
@@ -112,7 +124,7 @@ appear aligned in most editors and monospaced fonts:
 
 Rationale: Consistent formatting makes it easier to understand a document.
 
-[cjk-characters]: https://en.wikipedia.org/wiki/CJK_characters
-[emoji]: https://en.wikipedia.org/wiki/Emoji
+[cjk-characters]: https://wikipedia.org/wiki/CJK_characters
+[emoji]: https://wikipedia.org/wiki/Emoji
 [gfm-table-060]: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables
-[latin-script]: https://en.wikipedia.org/wiki/Latin_script
+[latin-script]: https://wikipedia.org/wiki/Latin_script

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -188,6 +188,10 @@
   {
     "parameters": [
       {
+        "name": "include_front_matter",
+        "description": "Include front matter content"
+      },
+      {
         "name": "lines_above",
         "description": "Blank lines above heading"
       },

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint",
-  "version": "0.40.0",
+  "version": "0.41.1",
   "patterns": [
     {
       "patternId": "MD001",
@@ -208,6 +208,10 @@
       "level": "Info",
       "category": "CodeStyle",
       "parameters": [
+        {
+          "name": "include_front_matter",
+          "default": false
+        },
         {
           "name": "lines_above",
           "default": 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "glob": "10.3.10",
         "js-yaml": "^4.1.0",
         "lodash": "4.17.21",
-        "markdownlint": "0.40.0",
+        "markdownlint": "0.41.1",
         "node-fetch": "3.3.2",
         "typescript": "5.3.3"
       },
@@ -3248,9 +3248,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "license": "MIT",
       "dependencies": {
         "micromark": "4.0.2",
@@ -3261,10 +3261,10 @@
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
         "micromark-util-types": "2.0.2",
-        "string-width": "8.1.0"
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
@@ -3283,13 +3283,13 @@
       }
     },
     "node_modules/markdownlint/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -7002,9 +7002,9 @@
       "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
     },
     "markdownlint": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "requires": {
         "micromark": "4.0.2",
         "micromark-core-commonmark": "2.0.3",
@@ -7014,7 +7014,7 @@
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
         "micromark-util-types": "2.0.2",
-        "string-width": "8.1.0"
+        "string-width": "8.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7023,12 +7023,12 @@
           "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
         },
         "string-width": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-          "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+          "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
           "requires": {
-            "get-east-asian-width": "^1.3.0",
-            "strip-ansi": "^7.1.0"
+            "get-east-asian-width": "^1.5.0",
+            "strip-ansi": "^7.1.2"
           }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "glob": "10.3.10",
     "js-yaml": "^4.1.0",
     "lodash": "4.17.21",
-    "markdownlint": "0.40.0",
+    "markdownlint": "0.41.1",
     "node-fetch": "3.3.2",
     "typescript": "5.3.3"
   },


### PR DESCRIPTION
## Summary
- Bumps the wrapped `markdownlint` dependency from `0.40.0` to `0.41.1`.
- Regenerates `docs/patterns.json`, `docs/description/description.json`, and the affected `docs/description/MD*.md` files via `npm run build:docs`.
- No rules were added or removed between these versions. `MD022` (blanks-around-headings) gained a new `include_front_matter` parameter (default `false`), reflected in `docs/patterns.json` / `description.json`. Wording-only updates landed in MD001, MD011, MD025, MD026, MD028, MD029, MD034, MD035, MD041, MD042, MD045, MD060 description files.
- `markdownlint@0.41.1`'s declared `engines.node` is `>=22`. This repo's `Dockerfile` already builds/runs on `node:25-alpine3.23` (both stages), so the packaged image is unaffected. No Node version bump was needed there.

## Test plan
- [x] `npm install` — package-lock.json regenerated, install succeeds (only an `EBADENGINE` advisory warning, no error).
- [x] `npm run build:docs` — docs regenerated successfully, reviewed diff (see above).
- [x] `npm run build` (`tsc --showConfig && tsc`) — passes, no type errors.
- [x] `npm test` (mocha) — all 7 tests pass.
- [ ] `npm run lint` — **could not run**: this fails on the unmodified `master` branch too (verified via `git stash`). The repo declares `eslint@9.36.0` as a devDependency but ships no `eslint.config.js` and the `lint` script still uses the removed `--ext` flag from ESLint v8. This is a pre-existing issue unrelated to this bump; flagging here rather than silently fixing it as part of a dependency update, since migrating to ESLint 9's flat config is a separate decision.
- [ ] `docker build -t codacy-markdownlint .` — **could not validate locally**: the sandbox this PR was prepared in cannot reach `raw.githubusercontent.com` from inside the Docker builder stage (network unreachable), which is the exact failure mode documented in the README's "Common failure modes" table. Docs were regenerated locally (outside Docker) and committed per that documented workaround, so the Docker build's `npm run build:docs` step should be a no-op in an environment with proper network access. Please rely on the CI `publish_docker_local` / `codacy/shell` check for this.
- [ ] `codacy-plugins-test` — **could not run locally** for the same network reason (no working local image to test against). Relying on the CI `plugins_test` job.

I'll poll CI checks on this PR and address anything that comes up (in particular I want to confirm the Docker build and plugins-test pass with real network access, and that the `EBADENGINE` node/test job doesn't fail on an older CircleCI Node executor version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)